### PR TITLE
Switch to full build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It shall NOT be edited by hand.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Shipped version:** 3.12.0~ynh2
+**Shipped version:** 3.12.0~ynh3
 ## Documentation and resources
 
 - Upstream app code repository: <https://codeberg.org/silverpill/mitra>

--- a/README_es.md
+++ b/README_es.md
@@ -23,7 +23,7 @@ No se debe editar a mano.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versión actual:** 3.12.0~ynh2
+**Versión actual:** 3.12.0~ynh3
 ## Documentaciones y recursos
 
 - Repositorio del código fuente oficial de la aplicación : <https://codeberg.org/silverpill/mitra>

--- a/README_eu.md
+++ b/README_eu.md
@@ -23,7 +23,7 @@ EZ editatu eskuz.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Paketatutako bertsioa:** 3.12.0~ynh2
+**Paketatutako bertsioa:** 3.12.0~ynh3
 ## Dokumentazioa eta baliabideak
 
 - Jatorrizko aplikazioaren kode-gordailua: <https://codeberg.org/silverpill/mitra>

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Il NE doit PAS être modifié à la main.
 Vos sites web seront compatibles avec **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** et bien d'autres encore.
 
 
-**Version incluse :** 3.12.0~ynh2
+**Version incluse :** 3.12.0~ynh3
 ## Documentations et ressources
 
 - Dépôt de code officiel de l’app : <https://codeberg.org/silverpill/mitra>

--- a/README_gl.md
+++ b/README_gl.md
@@ -23,7 +23,7 @@ NON debe editarse manualmente.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versión proporcionada:** 3.12.0~ynh2
+**Versión proporcionada:** 3.12.0~ynh3
 ## Documentación e recursos
 
 - Repositorio de orixe do código: <https://codeberg.org/silverpill/mitra>

--- a/README_id.md
+++ b/README_id.md
@@ -23,7 +23,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versi terkirim:** 3.12.0~ynh2
+**Versi terkirim:** 3.12.0~ynh3
 ## Dokumentasi dan sumber daya
 
 - Depot kode aplikasi hulu: <https://codeberg.org/silverpill/mitra>

--- a/README_nl.md
+++ b/README_nl.md
@@ -23,7 +23,7 @@ Hij mag NIET handmatig aangepast worden.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Geleverde versie:** 3.12.0~ynh2
+**Geleverde versie:** 3.12.0~ynh3
 ## Documentatie en bronnen
 
 - Upstream app codedepot: <https://codeberg.org/silverpill/mitra>

--- a/README_pl.md
+++ b/README_pl.md
@@ -23,7 +23,7 @@ Nie powinno być ono edytowane ręcznie.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Dostarczona wersja:** 3.12.0~ynh2
+**Dostarczona wersja:** 3.12.0~ynh3
 ## Dokumentacja i zasoby
 
 - Repozytorium z kodem źródłowym: <https://codeberg.org/silverpill/mitra>

--- a/README_ru.md
+++ b/README_ru.md
@@ -23,7 +23,7 @@
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Поставляемая версия:** 3.12.0~ynh2
+**Поставляемая версия:** 3.12.0~ynh3
 ## Документация и ресурсы
 
 - Репозиторий кода главной ветки приложения: <https://codeberg.org/silverpill/mitra>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -23,7 +23,7 @@
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**分发版本：** 3.12.0~ynh2
+**分发版本：** 3.12.0~ynh3
 ## 文档与资源
 
 - 上游应用代码库： <https://codeberg.org/silverpill/mitra>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Mitra"
 description.en = "Federated micro-blogging platform."
 description.fr = "Plateforme de micro-blogging fédéré"
 
-version = "3.12.0~ynh2"
+version = "3.12.0~ynh3"
 
 maintainers = ["Papa Dragon"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,3 +4,4 @@
 # COMMON VARIABLES AND CUSTOM HELPERS
 #=================================================
 
+nodejs_version="22"

--- a/scripts/install
+++ b/scripts/install
@@ -19,7 +19,7 @@ ynh_script_progression "Setting up source files..."
 
 # Download, check integrity, uncompress and patch the source from GitHub
 ynh_setup_source --dest_dir="$install_dir"
-ynh_setup_source --dest_dir="$install_dir/dist" --source_id="mitra-web"
+ynh_setup_source --dest_dir="$install_dir/mitra-web-src" --source_id="mitra-web"
 
 
 #=================================================
@@ -48,6 +48,25 @@ ln -s $install_dir/target/release/mitractl /usr/bin/
 
 ynh_safe_rm "$install_dir/.cargo"
 ynh_safe_rm "$install_dir/.rustup"
+
+#==============================================
+# BUILD MITRA-WEB
+#=================================================
+
+ynh_script_progression "Building web client... (a little more patience!)" --weight=20
+
+pushd "$install_dir/mitra-web-src"
+    ynh_nodejs_install
+	ynh_hide_warnings npm install --no-save
+	ynh_hide_warnings npx allow-scripts
+    echo "VITE_BACKEND_URL=" > .env.local
+    ynh_hide_warnings npm run build
+    mv dist $install_dir/
+popd
+
+chown -Rv $app:www-data $install_dir/dist
+
+ynh_safe_rm "$install_dir/mitra-web-src"
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -37,7 +37,7 @@ ynh_config_remove_nginx
 
 # Download, check integrity, uncompress and patch the source from GitHub
 ynh_setup_source --dest_dir="$install_dir"
-ynh_setup_source --dest_dir="$install_dir/dist" --source_id="mitra-web"
+ynh_setup_source --dest_dir="$install_dir/mitra-web-src" --source_id="mitra-web"
 
 #=================================================
 # INSTALL RUST/CARGO
@@ -66,6 +66,25 @@ ln -s $install_dir/target/release/mitractl /usr/bin/
 
 ynh_safe_rm "$install_dir/.cargo"
 ynh_safe_rm "$install_dir/.rustup"
+
+#==============================================
+# BUILD MITRA-WEB
+#=================================================
+
+ynh_script_progression "Building web client... (a little more patience!)" --weight=20
+
+pushd "$install_dir/mitra-web-src"
+    ynh_nodejs_install
+	ynh_hide_warnings npm install --no-save
+	ynh_hide_warnings npx allow-scripts
+    echo "VITE_BACKEND_URL=" > .env.local
+    ynh_hide_warnings npm run build
+    mv dist $install_dir/
+popd
+
+chown -Rv $app:www-data $install_dir/dist
+
+ynh_safe_rm "$install_dir/mitra-web-src"
 
 #=================================================
 # ADD A CONFIGURATION


### PR DESCRIPTION
Autoupdate to 3.12.0~ynh2 broke the package: instead of loading the pre-built web-client, the source code only was fetched (and no build for this client was present in the install/upgrade scripts).
=> Fixed building the web client during install.