### PR TITLE
Upgrade to v3.18.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,55 @@
+---
+name: Bug report
+about: When creating a bug report, please use the following template to provide all the relevant information and help debugging efficiently.
+
+---
+
+**How to post a meaningful bug report**
+1. *Read this whole template first.*
+2. *Determine if you are on the right place:*
+   - *If you were performing an action on the app from the webadmin or the CLI (install, update, backup, restore, change_url...), you are on the right place!*
+   - *Otherwise, the issue may be due to the app itself. Refer to its documentation or repository for help.*
+   - *When in doubt, post here and we will figure it out together.*
+3. *Delete the italic comments as you write over them below, and remove this guide.*
+--- 
+
+### Describe the bug
+
+*A clear and concise description of what the bug is.*
+
+### Context
+
+- Hardware: *VPS bought online / Old laptop or computer / Raspberry Pi at home / Internet Cube with VPN / Other ARM board / ...*
+- YunoHost version: x.x.x
+- I have access to my server: *Through SSH | through the webadmin | direct access via keyboard / screen | ...*
+- Are you in a special context or did you perform some particular tweaking on your YunoHost instance?: *no / yes*
+  - If yes, please explain:
+- Using, or trying to install package version/branch:
+- If upgrading, current package version: *can be found in the admin, or with `yunohost app info $app_id`*
+
+### Steps to reproduce
+
+- *If you performed a command from the CLI, the command itself is enough. For example:*
+    ```sh
+    sudo yunohost app install the_app
+    ```
+- *If you used the webadmin, please perform the equivalent command from the CLI first.*
+- *If the error occurs in your browser, explain what you did:*
+   1. *Go to '...'*
+   2. *Click on '...'*
+   3. *Scroll down to '...'*
+   4. *See error*
+
+### Expected behavior
+
+*A clear and concise description of what you expected to happen. You can remove this section if the command above is enough to understand your intent.*
+
+### Logs
+
+*When an operation fails, YunoHost provides a simple way to share the logs.*
+- *In the webadmin, the error message contains a link to the relevant log page. On that page, you will be able to 'Share with Yunopaste'. If you missed it, the logs of previous operations are also available under Tools > Logs.*
+- *In command line, the command to share the logs is displayed at the end of the operation and looks like `yunohost log display [log name] --share`. If you missed it, you can find the log ID of a previous operation using `yunohost log list`.*
+
+*After sharing the log, please copypaste directly the link provided by YunoHost (to help readability, no need to copypaste the entire content of the log here, just the link is enough...)*
+
+*If applicable and useful, add screenshots to help explain your problem.*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Problem
+
+- *Description of why you made this PR*
+
+## Solution
+
+- *And how do you fix that problem*
+
+## PR Status
+
+- [ ] Code finished and ready to be reviewed/tested
+- [ ] The fix/enhancement were manually tested (if applicable)
+
+## Automatic tests
+
+Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It shall NOT be edited by hand.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Shipped version:** 3.17.0~ynh1
+**Shipped version:** 3.18.0~ynh1
 ## Documentation and resources
 
 - Upstream app code repository: <https://codeberg.org/silverpill/mitra>

--- a/README_es.md
+++ b/README_es.md
@@ -23,7 +23,7 @@ No se debe editar a mano.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versión actual:** 3.17.0~ynh1
+**Versión actual:** 3.18.0~ynh1
 ## Documentaciones y recursos
 
 - Repositorio del código fuente oficial de la aplicación : <https://codeberg.org/silverpill/mitra>

--- a/README_eu.md
+++ b/README_eu.md
@@ -23,7 +23,7 @@ EZ editatu eskuz.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Paketatutako bertsioa:** 3.17.0~ynh1
+**Paketatutako bertsioa:** 3.18.0~ynh1
 ## Dokumentazioa eta baliabideak
 
 - Jatorrizko aplikazioaren kode-gordailua: <https://codeberg.org/silverpill/mitra>

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Il NE doit PAS être modifié à la main.
 Vos sites web seront compatibles avec **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** et bien d'autres encore.
 
 
-**Version incluse :** 3.17.0~ynh1
+**Version incluse :** 3.18.0~ynh1
 ## Documentations et ressources
 
 - Dépôt de code officiel de l’app : <https://codeberg.org/silverpill/mitra>

--- a/README_gl.md
+++ b/README_gl.md
@@ -23,7 +23,7 @@ NON debe editarse manualmente.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versión proporcionada:** 3.17.0~ynh1
+**Versión proporcionada:** 3.18.0~ynh1
 ## Documentación e recursos
 
 - Repositorio de orixe do código: <https://codeberg.org/silverpill/mitra>

--- a/README_id.md
+++ b/README_id.md
@@ -23,7 +23,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Versi terkirim:** 3.17.0~ynh1
+**Versi terkirim:** 3.18.0~ynh1
 ## Dokumentasi dan sumber daya
 
 - Depot kode aplikasi hulu: <https://codeberg.org/silverpill/mitra>

--- a/README_nl.md
+++ b/README_nl.md
@@ -23,7 +23,7 @@ Hij mag NIET handmatig aangepast worden.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Geleverde versie:** 3.17.0~ynh1
+**Geleverde versie:** 3.18.0~ynh1
 ## Documentatie en bronnen
 
 - Upstream app codedepot: <https://codeberg.org/silverpill/mitra>

--- a/README_pl.md
+++ b/README_pl.md
@@ -23,7 +23,7 @@ Nie powinno być ono edytowane ręcznie.
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Dostarczona wersja:** 3.17.0~ynh1
+**Dostarczona wersja:** 3.18.0~ynh1
 ## Dokumentacja i zasoby
 
 - Repozytorium z kodem źródłowym: <https://codeberg.org/silverpill/mitra>

--- a/README_ru.md
+++ b/README_ru.md
@@ -23,7 +23,7 @@
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**Поставляемая версия:** 3.17.0~ynh1
+**Поставляемая версия:** 3.18.0~ynh1
 ## Документация и ресурсы
 
 - Репозиторий кода главной ветки приложения: <https://codeberg.org/silverpill/mitra>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -23,7 +23,7 @@
 Your server will be compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **(streams)**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
 
 
-**分发版本：** 3.17.0~ynh1
+**分发版本：** 3.18.0~ynh1
 ## 文档与资源
 
 - 上游应用代码库： <https://codeberg.org/silverpill/mitra>

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/manifest.v2.schema.json
+
 packaging_format = 2
 
 id = "mitra"
@@ -5,7 +7,7 @@ name = "Mitra"
 description.en = "Federated micro-blogging platform."
 description.fr = "Plateforme de micro-blogging fédéré"
 
-version = "3.17.0~ynh1"
+version = "3.18.0~ynh1"
 
 maintainers = ["Papa Dragon"]
 
@@ -43,18 +45,18 @@ ram.runtime = "50M"
 [resources]
 
     [resources.sources]
-        [resources.sources.main]
-        url = "https://codeberg.org/silverpill/mitra/archive/v3.17.0.tar.gz"
-        sha256 = "56283ebc3605d426ce08187cb9841c9f84e9ecf899b53d7dc9d654358493f5f9"
+    [resources.sources.main]
+    url = "https://codeberg.org/silverpill/mitra/archive/v3.18.0.tar.gz"
+    sha256 = "ad897c576b04e4a8cbb227301a6a55eca77d696c6fe7b17c42a1a3ccdcfed500"
 
-        autoupdate.strategy = "latest_forgejo_release"
+    autoupdate.strategy = "latest_forgejo_release"
 
-        [resources.sources.mitra-web]
-        url = "https://codeberg.org/silverpill/mitra-web/archive/v3.17.0.tar.gz"
-        sha256 = "a56d3404575e27a24e4882087e7cf928c7ba58a38907d3e6a0065021ace960d5"
+    [resources.sources.mitra-web]
+    url = "https://codeberg.org/silverpill/mitra-web/archive/v3.18.0.tar.gz"
+    sha256 = "01b43f6d25f30a0f5868c5bf935fe9cd1d9be1ded0368ac8cc14f5af3083b4f0"
 
-        autoupdate.upstream = "https://codeberg.org/silverpill/mitra-web"
-        autoupdate.strategy = "latest_forgejo_release"
+    autoupdate.upstream = "https://codeberg.org/silverpill/mitra-web"
+    autoupdate.strategy = "latest_forgejo_release"
 
     [resources.system_user]
 

--- a/tests.toml
+++ b/tests.toml
@@ -14,5 +14,8 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-    test_upgrade_from.8fd0bef8eeb983e3a6fbcb46b73c713d7f5bf7d5.name = "Upgrade from 3.10.0~ynh1"
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
 
+    test_upgrade_from.8fd0bef8eeb983e3a6fbcb46b73c713d7f5bf7d5.name = "Upgrade from 3.10.0~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v3.18.0: https://codeberg.org/silverpill/mitra/releases/tag/v3.18.0
- `mitra-web` v3.18.0: https://codeberg.org/silverpill/mitra-web/releases/tag/v3.18.0